### PR TITLE
fix: fix footer position to always be at the bottom

### DIFF
--- a/src/pages/imprint-de.tsx
+++ b/src/pages/imprint-de.tsx
@@ -16,105 +16,112 @@ const Imprint = () => {
   return (
     <Stack
       direction="column"
+      justify="space-between"
       gap="16px"
-      css={{ paddingTop: '3rem', marginInline: '4rem', marginBottom: '2.5rem' }}
+      css={{
+        paddingTop: '3rem',
+        marginInline: '4rem',
+        height: 'calc(100vh - 5.5rem)',
+      }}
     >
-      <Link as={GatsbyLink} to="/">
-        <Stack gap="8px" align="center">
-          <FontAwesomeIcon size="lg" color="grey" icon={faChevronLeft} />
-          <Text css={{ fontSize: '16px' }}>Zurück</Text>
-        </Stack>
-      </Link>
-      <Heading size="md" as="h1" css={{ fontWeight: 800, fontSize: '20px' }}>
-        Impressum
-      </Heading>
+      <Stack direction="column" gap="16px">
+        <Link as={GatsbyLink} to="/">
+          <Stack gap="8px" align="center">
+            <FontAwesomeIcon size="lg" color="grey" icon={faChevronLeft} />
+            <Text css={{ fontSize: '16px' }}>Zurück</Text>
+          </Stack>
+        </Link>
+        <Heading size="md" as="h1" css={{ fontWeight: 800, fontSize: '20px' }}>
+          Impressum
+        </Heading>
 
-      <Heading size="sm" as="h2">
-        Angaben gem&auml;&szlig; &sect; 5 TMG
-      </Heading>
-      <Text>
-        {name}
-        <br />
-        {company}
-        <br />
-        {address.street}
-        <br />
-        {address.city}
-      </Text>
-      <Heading size="sm" as="h2">
-        Kontakt
-      </Heading>
-      <Text>
-        {phone}
-        <br />
-        {email}
-      </Text>
-      <Heading size="sm" as="h2">
-        Umsatzsteuer-ID
-      </Heading>
-      <Text>
-        Umsatzsteuer-Identifikationsnummer gem&auml;&szlig; &sect; 27 a
-        Umsatzsteuergesetz:
-        <br />
-        {vatId}
-      </Text>
-      <Heading size="sm" as="h2">
-        Angaben zur Berufs&shy;haftpflicht&shy;versicherung
-      </Heading>
-      <Text>
-        <strong>Name und Sitz des Versicherers:</strong>
-        <br />
-        {insurance.name}
-        <br />
-        {insurance.address.street}
-        <br />
-        {insurance.address.city}
-      </Text>
-      <Text>
-        <strong>Geltungsraum der Versicherung:</strong>
-        <br />
-        {insurance.scope}
-      </Text>
-      <Heading size="sm" as="h2">
-        Redaktionell verantwortlich
-      </Heading>
-      <Text>
-        {name}
-        <br />
-        {address.street}
-        <br />
-        {address.city}
-      </Text>
-      <Heading size="sm" as="h2">
-        EU-Streitschlichtung
-      </Heading>
-      <Text>
-        Die Europ&auml;ische Kommission stellt eine Plattform zur
-        Online-Streitbeilegung (OS) bereit:
-        <Text
-          as="a"
-          href="https://ec.europa.eu/consumers/odr/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          https://ec.europa.eu/consumers/odr/
+        <Heading size="sm" as="h2">
+          Angaben gem&auml;&szlig; &sect; 5 TMG
+        </Heading>
+        <Text>
+          {name}
+          <br />
+          {company}
+          <br />
+          {address.street}
+          <br />
+          {address.city}
         </Text>
-        .<br /> Unsere E-Mail-Adresse finden Sie oben im Impressum.
-      </Text>
-      <Heading size="sm" as="h2">
-        Verbraucher&shy;streit&shy;beilegung/Universal&shy;schlichtungs&shy;stelle
-      </Heading>
-      <Text>
-        Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren
-        vor einer Verbraucherschlichtungsstelle teilzunehmen.
-      </Text>
-      <Text>
-        Quelle:
-        <Text as="a" href="https://www.e-recht24.de">
-          eRecht24
+        <Heading size="sm" as="h2">
+          Kontakt
+        </Heading>
+        <Text>
+          {phone}
+          <br />
+          {email}
         </Text>
-      </Text>
-      <Footer css={{ marginTop: '2rem' }}>
+        <Heading size="sm" as="h2">
+          Umsatzsteuer-ID
+        </Heading>
+        <Text>
+          Umsatzsteuer-Identifikationsnummer gem&auml;&szlig; &sect; 27 a
+          Umsatzsteuergesetz:
+          <br />
+          {vatId}
+        </Text>
+        <Heading size="sm" as="h2">
+          Angaben zur Berufs&shy;haftpflicht&shy;versicherung
+        </Heading>
+        <Text>
+          <strong>Name und Sitz des Versicherers:</strong>
+          <br />
+          {insurance.name}
+          <br />
+          {insurance.address.street}
+          <br />
+          {insurance.address.city}
+        </Text>
+        <Text>
+          <strong>Geltungsraum der Versicherung:</strong>
+          <br />
+          {insurance.scope}
+        </Text>
+        <Heading size="sm" as="h2">
+          Redaktionell verantwortlich
+        </Heading>
+        <Text>
+          {name}
+          <br />
+          {address.street}
+          <br />
+          {address.city}
+        </Text>
+        <Heading size="sm" as="h2">
+          EU-Streitschlichtung
+        </Heading>
+        <Text>
+          Die Europ&auml;ische Kommission stellt eine Plattform zur
+          Online-Streitbeilegung (OS) bereit:
+          <Text
+            as="a"
+            href="https://ec.europa.eu/consumers/odr/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            https://ec.europa.eu/consumers/odr/
+          </Text>
+          .<br /> Unsere E-Mail-Adresse finden Sie oben im Impressum.
+        </Text>
+        <Heading size="sm" as="h2">
+          Verbraucher&shy;streit&shy;beilegung/Universal&shy;schlichtungs&shy;stelle
+        </Heading>
+        <Text>
+          Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren
+          vor einer Verbraucherschlichtungsstelle teilzunehmen.
+        </Text>
+        <Text>
+          Quelle:
+          <Text as="a" href="https://www.e-recht24.de">
+            eRecht24
+          </Text>
+        </Text>
+      </Stack>
+      <Footer css={{ marginTop: '2rem', paddingBottom: '2.5rem' }}>
         <Link as={GatsbyLink} to="/">
           CV
         </Link>

--- a/src/pages/imprint-en.tsx
+++ b/src/pages/imprint-en.tsx
@@ -15,104 +15,112 @@ const Imprint = () => {
   return (
     <Stack
       direction="column"
+      justify="space-between"
       gap="16px"
-      css={{ paddingTop: '3rem', marginInline: '4rem', marginBottom: '2.5rem' }}
+      css={{
+        paddingTop: '3rem',
+        marginInline: '4rem',
+        height: 'calc(100vh - 5.5rem)',
+      }}
     >
-      <Link as={GatsbyLink} to="/">
-        <Stack gap="8px" align="center">
-          <FontAwesomeIcon size="lg" color="grey" icon={faChevronLeft} />
-          <Text css={{ fontSize: '16px' }}>Back</Text>
-        </Stack>
-      </Link>
-      <Heading size="md" as="h1" css={{ fontWeight: 800, fontSize: '20px' }}>
-        Imprint
-      </Heading>
+      <Stack direction="column" gap="16px">
+        <Link as={GatsbyLink} to="/">
+          <Stack gap="8px" align="center">
+            <FontAwesomeIcon size="lg" color="grey" icon={faChevronLeft} />
+            <Text css={{ fontSize: '16px' }}>Back</Text>
+          </Stack>
+        </Link>
+        <Heading size="md" as="h1" css={{ fontWeight: 800, fontSize: '20px' }}>
+          Imprint
+        </Heading>
 
-      <Heading size="sm" as="h2">
-        Information according to &sect; 5 TMG
-      </Heading>
-      <Text>
-        {name}
-        <br />
-        {company}
-        <br />
-        {address.street}
-        <br />
-        {address.city}
-      </Text>
-      <Heading size="sm" as="h2">
-        Contact
-      </Heading>
-      <Text>
-        {phone}
-        <br />
-        {email}
-      </Text>
-      <Heading size="sm" as="h2">
-        VAT ID
-      </Heading>
-      <Text>
-        VAT identification number according to &sect; 27 a Value Added Tax Act:
-        <br />
-        {vatId}
-      </Text>
-      <Heading size="sm" as="h2">
-        Details of professional liability insurance
-      </Heading>
-      <Text>
-        <strong>Name and registered office of the insurer:</strong>
-        <br />
-        {insurance.name}
-        <br />
-        {insurance.address.street}
-        <br />
-        {insurance.address.city}
-      </Text>
-      <Text>
-        <strong>Area of validity of the insurance:</strong>
-        <br />
-        {insurance.scope}
-      </Text>
-      <Heading size="sm" as="h2">
-        Redaktionell verantwortlich
-      </Heading>
-      <Text>
-        {name}
-        <br />
-        {address.street}
-        <br />
-        {address.city}
-      </Text>
-      <Heading size="sm" as="h2">
-        EU Dispute Settlement
-      </Heading>
-      <Text>
-        The European Commission provides a platform for the Online Dispute
-        Resolution (ODR):
-        <Text
-          as="a"
-          href="https://ec.europa.eu/consumers/odr/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          https://ec.europa.eu/consumers/odr/
+        <Heading size="sm" as="h2">
+          Information according to &sect; 5 TMG
+        </Heading>
+        <Text>
+          {name}
+          <br />
+          {company}
+          <br />
+          {address.street}
+          <br />
+          {address.city}
         </Text>
-        .<br /> You can find our e-mail address in the imprint above.
-      </Text>
-      <Heading size="sm" as="h2">
-        Consumer dispute resolution / Universal arbitration board
-      </Heading>
-      <Text>
-        We are not willing or obligated to participate in dispute resolution
-        proceedings before a consumer arbitration board.
-      </Text>
-      <Text>
-        Source:
-        <Text as="a" href="https://www.e-recht24.de">
-          eRecht24
+        <Heading size="sm" as="h2">
+          Contact
+        </Heading>
+        <Text>
+          {phone}
+          <br />
+          {email}
         </Text>
-      </Text>
-      <Footer css={{ marginTop: '2rem' }}>
+        <Heading size="sm" as="h2">
+          VAT ID
+        </Heading>
+        <Text>
+          VAT identification number according to &sect; 27 a Value Added Tax
+          Act:
+          <br />
+          {vatId}
+        </Text>
+        <Heading size="sm" as="h2">
+          Details of professional liability insurance
+        </Heading>
+        <Text>
+          <strong>Name and registered office of the insurer:</strong>
+          <br />
+          {insurance.name}
+          <br />
+          {insurance.address.street}
+          <br />
+          {insurance.address.city}
+        </Text>
+        <Text>
+          <strong>Area of validity of the insurance:</strong>
+          <br />
+          {insurance.scope}
+        </Text>
+        <Heading size="sm" as="h2">
+          Redaktionell verantwortlich
+        </Heading>
+        <Text>
+          {name}
+          <br />
+          {address.street}
+          <br />
+          {address.city}
+        </Text>
+        <Heading size="sm" as="h2">
+          EU Dispute Settlement
+        </Heading>
+        <Text>
+          The European Commission provides a platform for the Online Dispute
+          Resolution (ODR):
+          <Text
+            as="a"
+            href="https://ec.europa.eu/consumers/odr/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            https://ec.europa.eu/consumers/odr/
+          </Text>
+          .<br /> You can find our e-mail address in the imprint above.
+        </Text>
+        <Heading size="sm" as="h2">
+          Consumer dispute resolution / Universal arbitration board
+        </Heading>
+        <Text>
+          We are not willing or obligated to participate in dispute resolution
+          proceedings before a consumer arbitration board.
+        </Text>
+        <Text>
+          Source:
+          <Text as="a" href="https://www.e-recht24.de">
+            eRecht24
+          </Text>
+        </Text>
+      </Stack>
+      <Footer css={{ marginTop: '2rem', paddingBottom: '2.5rem' }}>
         <Link as={GatsbyLink} to="/">
           CV
         </Link>

--- a/src/pages/privacy-de.tsx
+++ b/src/pages/privacy-de.tsx
@@ -15,374 +15,383 @@ const Privacy = () => {
   return (
     <Stack
       direction="column"
+      justify="space-between"
       gap="16px"
-      css={{ paddingTop: '3rem', marginInline: '4rem', marginBottom: '2.5rem' }}
+      css={{
+        paddingTop: '3rem',
+        marginInline: '4rem',
+        height: 'calc(100vh - 5.5rem)',
+      }}
     >
-      <Link as={GatsbyLink} to="/">
-        <Stack gap="8px" align="center">
-          <FontAwesomeIcon size="lg" color="grey" icon={faChevronLeft} />
-          <Text css={{ fontSize: '16px' }}>Zurück</Text>
-        </Stack>
-      </Link>
-      <Heading size="md" as="h1" css={{ fontWeight: 800, fontSize: '20px' }}>
-        Datenschutz&shy;erkl&auml;rung
-      </Heading>
-      <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
-        1. Datenschutz auf einen Blick
-      </Heading>
-      <Heading size="sm" as="h3">
-        Allgemeine Hinweise
-      </Heading>
-      <Text>
-        Die folgenden Hinweise geben einen einfachen &Uuml;berblick
-        dar&uuml;ber, was mit Ihren personenbezogenen Daten passiert, wenn Sie
-        diese Website besuchen. Personenbezogene Daten sind alle Daten, mit
-        denen Sie pers&ouml;nlich identifiziert werden k&ouml;nnen.
-        Ausf&uuml;hrliche Informationen zum Thema Datenschutz entnehmen Sie
-        unserer unter diesem Text aufgef&uuml;hrten Datenschutzerkl&auml;rung.
-      </Text>
-      <Heading size="sm" as="h3">
-        Datenerfassung auf dieser Website
-      </Heading>
-      <Heading size="xs" as="h4">
-        Wer ist verantwortlich f&uuml;r die Datenerfassung auf dieser Website?
-      </Heading>
-      <Text>
-        Die Datenverarbeitung auf dieser Website erfolgt durch den
-        Websitebetreiber. Dessen Kontaktdaten k&ouml;nnen Sie dem Abschnitt
-        &bdquo;Hinweis zur Verantwortlichen Stelle&ldquo; in dieser
-        Datenschutzerkl&auml;rung entnehmen.
-      </Text>
-      <Heading size="xs" as="h4">
-        Wie erfassen wir Ihre Daten?
-      </Heading>
-      <Text>
-        Ihre Daten werden zum einen dadurch erhoben, dass Sie uns diese
-        mitteilen. Hierbei kann es sich z.&nbsp;B. um Daten handeln, die Sie in
-        ein Kontaktformular eingeben.
-      </Text>
-      <Text>
-        Andere Daten werden automatisch oder nach Ihrer Einwilligung beim Besuch
-        der Website durch unsere IT-Systeme erfasst. Das sind vor allem
-        technische Daten (z.&nbsp;B. Internetbrowser, Betriebssystem oder
-        Uhrzeit des Seitenaufrufs). Die Erfassung dieser Daten erfolgt
-        automatisch, sobald Sie diese Website betreten.
-      </Text>
-      <Heading size="xs" as="h4">
-        Wof&uuml;r nutzen wir Ihre Daten?
-      </Heading>
-      <Text>
-        Ein Teil der Daten wird erhoben, um eine fehlerfreie Bereitstellung der
-        Website zu gew&auml;hrleisten. Andere Daten k&ouml;nnen zur Analyse
-        Ihres Nutzerverhaltens verwendet werden.
-      </Text>
-      <Heading size="xs" as="h4">
-        Welche Rechte haben Sie bez&uuml;glich Ihrer Daten?
-      </Heading>
-      <Text>
-        Sie haben jederzeit das Recht, unentgeltlich Auskunft &uuml;ber
-        Herkunft, Empf&auml;nger und Zweck Ihrer gespeicherten personenbezogenen
-        Daten zu erhalten. Sie haben au&szlig;erdem ein Recht, die Berichtigung
-        oder L&ouml;schung dieser Daten zu verlangen. Wenn Sie eine Einwilligung
-        zur Datenverarbeitung erteilt haben, k&ouml;nnen Sie diese Einwilligung
-        jederzeit f&uuml;r die Zukunft widerrufen. Au&szlig;erdem haben Sie das
-        Recht, unter bestimmten Umst&auml;nden die Einschr&auml;nkung der
-        Verarbeitung Ihrer personenbezogenen Daten zu verlangen. Des Weiteren
-        steht Ihnen ein Beschwerderecht bei der zust&auml;ndigen
-        Aufsichtsbeh&ouml;rde zu.
-      </Text>
-      <Text>
-        Hierzu sowie zu weiteren Fragen zum Thema Datenschutz k&ouml;nnen Sie
-        sich jederzeit an uns wenden.
-      </Text>
-      <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
-        2. Hosting
-      </Heading>
-      <Text>
-        Wir hosten die Inhalte unserer Website bei folgendem Anbieter:
-      </Text>
-      <Heading size="sm" as="h3">
-        Externes Hosting
-      </Heading>
-      <Text>
-        Diese Website wird extern gehostet. Die personenbezogenen Daten, die auf
-        dieser Website erfasst werden, werden auf den Servern des Hosters / der
-        Hoster gespeichert. Hierbei kann es sich v.&nbsp;a. um IP-Adressen,
-        Kontaktanfragen, Meta- und Kommunikationsdaten, Vertragsdaten,
-        Kontaktdaten, Namen, Websitezugriffe und sonstige Daten, die &uuml;ber
-        eine Website generiert werden, handeln.
-      </Text>
-      <Text>
-        Das externe Hosting erfolgt zum Zwecke der Vertragserf&uuml;llung
-        gegen&uuml;ber unseren potenziellen und bestehenden Kunden (Art. 6 Abs.
-        1 lit. b DSGVO) und im Interesse einer sicheren, schnellen und
-        effizienten Bereitstellung unseres Online-Angebots durch einen
-        professionellen Anbieter (Art. 6 Abs. 1 lit. f DSGVO). Sofern eine
-        entsprechende Einwilligung abgefragt wurde, erfolgt die Verarbeitung
-        ausschlie&szlig;lich auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO und
-        &sect; 25 Abs. 1 TTDSG, soweit die Einwilligung die Speicherung von
-        Cookies oder den Zugriff auf Informationen im Endger&auml;t des Nutzers
-        (z.&nbsp;B. Device-Fingerprinting) im Sinne des TTDSG umfasst. Die
-        Einwilligung ist jederzeit widerrufbar.
-      </Text>
-      <Text>
-        Unser(e) Hoster wird bzw. werden Ihre Daten nur insoweit verarbeiten,
-        wie dies zur Erf&uuml;llung seiner Leistungspflichten erforderlich ist
-        und unsere Weisungen in Bezug auf diese Daten befolgen.
-      </Text>
-      <Text>Wir setzen folgende(n) Hoster ein:</Text>
-      <Text>
-        GitHub, Inc.
-        <br />
-        88 Colin P Kelly Jr Street <br />
-        San Francisco, CA 94107 <br />
-        United States
-      </Text>
-      <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
-        3. Allgemeine Hinweise und Pflicht&shy;informationen
-      </Heading>
-      <Heading size="sm" as="h3">
-        Datenschutz
-      </Heading>
-      <Text>
-        Die Betreiber dieser Seiten nehmen den Schutz Ihrer pers&ouml;nlichen
-        Daten sehr ernst. Wir behandeln Ihre personenbezogenen Daten vertraulich
-        und entsprechend den gesetzlichen Datenschutzvorschriften sowie dieser
-        Datenschutzerkl&auml;rung.
-      </Text>
-      <Text>
-        Wenn Sie diese Website benutzen, werden verschiedene personenbezogene
-        Daten erhoben. Personenbezogene Daten sind Daten, mit denen Sie
-        pers&ouml;nlich identifiziert werden k&ouml;nnen. Die vorliegende
-        Datenschutzerkl&auml;rung erl&auml;utert, welche Daten wir erheben und
-        wof&uuml;r wir sie nutzen. Sie erl&auml;utert auch, wie und zu welchem
-        Zweck das geschieht.
-      </Text>
-      <Text>
-        Wir weisen darauf hin, dass die Daten&uuml;bertragung im Internet
-        (z.&nbsp;B. bei der Kommunikation per E-Mail) Sicherheitsl&uuml;cken
-        aufweisen kann. Ein l&uuml;ckenloser Schutz der Daten vor dem Zugriff
-        durch Dritte ist nicht m&ouml;glich.
-      </Text>
-      <Heading size="sm" as="h3">
-        Hinweis zur verantwortlichen Stelle
-      </Heading>
-      <Text>
-        Die verantwortliche Stelle f&uuml;r die Datenverarbeitung auf dieser
-        Website ist:
-      </Text>
-      <Text>
-        {name}
-        <br />
-        {address.street}
-        <br />
-        {address.zip} {address.city}
-      </Text>
-      <Text>
-        Telefon: {phone}
-        <br />
-        E-Mail: {email}
-      </Text>
-      <Text>
-        Verantwortliche Stelle ist die nat&uuml;rliche oder juristische Person,
-        die allein oder gemeinsam mit anderen &uuml;ber die Zwecke und Mittel
-        der Verarbeitung von personenbezogenen Daten (z.&nbsp;B. Namen,
-        E-Mail-Adressen o. &Auml;.) entscheidet.
-      </Text>
-      <Heading size="sm" as="h3">
-        Speicherdauer
-      </Heading>
-      <Text>
-        Soweit innerhalb dieser Datenschutzerkl&auml;rung keine speziellere
-        Speicherdauer genannt wurde, verbleiben Ihre personenbezogenen Daten bei
-        uns, bis der Zweck f&uuml;r die Datenverarbeitung entf&auml;llt. Wenn
-        Sie ein berechtigtes L&ouml;schersuchen geltend machen oder eine
-        Einwilligung zur Datenverarbeitung widerrufen, werden Ihre Daten
-        gel&ouml;scht, sofern wir keine anderen rechtlich zul&auml;ssigen
-        Gr&uuml;nde f&uuml;r die Speicherung Ihrer personenbezogenen Daten haben
-        (z.&nbsp;B. steuer- oder handelsrechtliche Aufbewahrungsfristen); im
-        letztgenannten Fall erfolgt die L&ouml;schung nach Fortfall dieser
-        Gr&uuml;nde.
-      </Text>
-      <Heading size="sm" as="h3">
-        Allgemeine Hinweise zu den Rechtsgrundlagen der Datenverarbeitung auf
-        dieser Website
-      </Heading>
-      <Text>
-        Sofern Sie in die Datenverarbeitung eingewilligt haben, verarbeiten wir
-        Ihre personenbezogenen Daten auf Grundlage von Art. 6 Abs. 1 lit. a
-        DSGVO bzw. Art. 9 Abs. 2 lit. a DSGVO, sofern besondere Datenkategorien
-        nach Art. 9 Abs. 1 DSGVO verarbeitet werden. Im Falle einer
-        ausdr&uuml;cklichen Einwilligung in die &Uuml;bertragung
-        personenbezogener Daten in Drittstaaten erfolgt die Datenverarbeitung
-        au&szlig;erdem auf Grundlage von Art. 49 Abs. 1 lit. a DSGVO. Sofern Sie
-        in die Speicherung von Cookies oder in den Zugriff auf Informationen in
-        Ihr Endger&auml;t (z.&nbsp;B. via Device-Fingerprinting) eingewilligt
-        haben, erfolgt die Datenverarbeitung zus&auml;tzlich auf Grundlage von
-        &sect; 25 Abs. 1 TTDSG. Die Einwilligung ist jederzeit widerrufbar. Sind
-        Ihre Daten zur Vertragserf&uuml;llung oder zur Durchf&uuml;hrung
-        vorvertraglicher Ma&szlig;nahmen erforderlich, verarbeiten wir Ihre
-        Daten auf Grundlage des Art. 6 Abs. 1 lit. b DSGVO. Des Weiteren
-        verarbeiten wir Ihre Daten, sofern diese zur Erf&uuml;llung einer
-        rechtlichen Verpflichtung erforderlich sind auf Grundlage von Art. 6
-        Abs. 1 lit. c DSGVO. Die Datenverarbeitung kann ferner auf Grundlage
-        unseres berechtigten Interesses nach Art. 6 Abs. 1 lit. f DSGVO
-        erfolgen. &Uuml;ber die jeweils im Einzelfall einschl&auml;gigen
-        Rechtsgrundlagen wird in den folgenden Abs&auml;tzen dieser
-        Datenschutzerkl&auml;rung informiert.
-      </Text>
-      <Heading size="sm" as="h3">
-        Widerruf Ihrer Einwilligung zur Datenverarbeitung
-      </Heading>
-      <Text>
-        Viele Datenverarbeitungsvorg&auml;nge sind nur mit Ihrer
-        ausdr&uuml;cklichen Einwilligung m&ouml;glich. Sie k&ouml;nnen eine
-        bereits erteilte Einwilligung jederzeit widerrufen. Die
-        Rechtm&auml;&szlig;igkeit der bis zum Widerruf erfolgten
-        Datenverarbeitung bleibt vom Widerruf unber&uuml;hrt.
-      </Text>
-      <Heading size="sm" as="h3">
-        Widerspruchsrecht gegen die Datenerhebung in besonderen F&auml;llen
-        sowie gegen Direktwerbung (Art. 21 DSGVO)
-      </Heading>
-      <Text>
-        WENN DIE DATENVERARBEITUNG AUF GRUNDLAGE VON ART. 6 ABS. 1 LIT. E ODER F
-        DSGVO ERFOLGT, HABEN SIE JEDERZEIT DAS RECHT, AUS GR&Uuml;NDEN, DIE SICH
-        AUS IHRER BESONDEREN SITUATION ERGEBEN, GEGEN DIE VERARBEITUNG IHRER
-        PERSONENBEZOGENEN DATEN WIDERSPRUCH EINZULEGEN; DIES GILT AUCH F&Uuml;R
-        EIN AUF DIESE BESTIMMUNGEN GEST&Uuml;TZTES PROFILING. DIE JEWEILIGE
-        RECHTSGRUNDLAGE, AUF DENEN EINE VERARBEITUNG BERUHT, ENTNEHMEN SIE
-        DIESER DATENSCHUTZERKL&Auml;RUNG. WENN SIE WIDERSPRUCH EINLEGEN, WERDEN
-        WIR IHRE BETROFFENEN PERSONENBEZOGENEN DATEN NICHT MEHR VERARBEITEN, ES
-        SEI DENN, WIR K&Ouml;NNEN ZWINGENDE SCHUTZW&Uuml;RDIGE GR&Uuml;NDE
-        F&Uuml;R DIE VERARBEITUNG NACHWEISEN, DIE IHRE INTERESSEN, RECHTE UND
-        FREIHEITEN &Uuml;BERWIEGEN ODER DIE VERARBEITUNG DIENT DER
-        GELTENDMACHUNG, AUS&Uuml;BUNG ODER VERTEIDIGUNG VON
-        RECHTSANSPR&Uuml;CHEN (WIDERSPRUCH NACH ART. 21 ABS. 1 DSGVO).
-      </Text>
-      <Text>
-        WERDEN IHRE PERSONENBEZOGENEN DATEN VERARBEITET, UM DIREKTWERBUNG ZU
-        BETREIBEN, SO HABEN SIE DAS RECHT, JEDERZEIT WIDERSPRUCH GEGEN DIE
-        VERARBEITUNG SIE BETREFFENDER PERSONENBEZOGENER DATEN ZUM ZWECKE
-        DERARTIGER WERBUNG EINZULEGEN; DIES GILT AUCH F&Uuml;R DAS PROFILING,
-        SOWEIT ES MIT SOLCHER DIREKTWERBUNG IN VERBINDUNG STEHT. WENN SIE
-        WIDERSPRECHEN, WERDEN IHRE PERSONENBEZOGENEN DATEN ANSCHLIESSEND NICHT
-        MEHR ZUM ZWECKE DER DIREKTWERBUNG VERWENDET (WIDERSPRUCH NACH ART. 21
-        ABS. 2 DSGVO).
-      </Text>
-      <Heading size="sm" as="h3">
-        Beschwerde&shy;recht bei der zust&auml;ndigen Aufsichts&shy;beh&ouml;rde
-      </Heading>
-      <Text>
-        Im Falle von Verst&ouml;&szlig;en gegen die DSGVO steht den Betroffenen
-        ein Beschwerderecht bei einer Aufsichtsbeh&ouml;rde, insbesondere in dem
-        Mitgliedstaat ihres gew&ouml;hnlichen Aufenthalts, ihres Arbeitsplatzes
-        oder des Orts des mutma&szlig;lichen Versto&szlig;es zu. Das
-        Beschwerderecht besteht unbeschadet anderweitiger verwaltungsrechtlicher
-        oder gerichtlicher Rechtsbehelfe.
-      </Text>
-      <Heading size="sm" as="h3">
-        Recht auf Daten&shy;&uuml;bertrag&shy;barkeit
-      </Heading>
-      <Text>
-        Sie haben das Recht, Daten, die wir auf Grundlage Ihrer Einwilligung
-        oder in Erf&uuml;llung eines Vertrags automatisiert verarbeiten, an sich
-        oder an einen Dritten in einem g&auml;ngigen, maschinenlesbaren Format
-        aush&auml;ndigen zu lassen. Sofern Sie die direkte &Uuml;bertragung der
-        Daten an einen anderen Verantwortlichen verlangen, erfolgt dies nur,
-        soweit es technisch machbar ist.
-      </Text>
-      <Heading size="sm" as="h3">
-        Auskunft, Berichtigung und L&ouml;schung
-      </Heading>
-      <Text>
-        Sie haben im Rahmen der geltenden gesetzlichen Bestimmungen jederzeit
-        das Recht auf unentgeltliche Auskunft &uuml;ber Ihre gespeicherten
-        personenbezogenen Daten, deren Herkunft und Empf&auml;nger und den Zweck
-        der Datenverarbeitung und ggf. ein Recht auf Berichtigung oder
-        L&ouml;schung dieser Daten. Hierzu sowie zu weiteren Fragen zum Thema
-        personenbezogene Daten k&ouml;nnen Sie sich jederzeit an uns wenden.
-      </Text>
-      <Heading size="sm" as="h3">
-        Recht auf Einschr&auml;nkung der Verarbeitung
-      </Heading>
-      <Text>
-        Sie haben das Recht, die Einschr&auml;nkung der Verarbeitung Ihrer
-        personenbezogenen Daten zu verlangen. Hierzu k&ouml;nnen Sie sich
-        jederzeit an uns wenden. Das Recht auf Einschr&auml;nkung der
-        Verarbeitung besteht in folgenden F&auml;llen:
-      </Text>
-      <ul>
-        <li>
-          <Text>
-            Wenn Sie die Richtigkeit Ihrer bei uns gespeicherten
-            personenbezogenen Daten bestreiten, ben&ouml;tigen wir in der Regel
-            Zeit, um dies zu &uuml;berpr&uuml;fen. F&uuml;r die Dauer der
-            Pr&uuml;fung haben Sie das Recht, die Einschr&auml;nkung der
-            Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
-          </Text>
-        </li>
-        <li>
-          <Text>
-            Wenn die Verarbeitung Ihrer personenbezogenen Daten
-            unrechtm&auml;&szlig;ig geschah/geschieht, k&ouml;nnen Sie statt der
-            L&ouml;schung die Einschr&auml;nkung der Datenverarbeitung
-            verlangen.
-          </Text>
-        </li>
-        <li>
-          <Text>
-            Wenn wir Ihre personenbezogenen Daten nicht mehr ben&ouml;tigen, Sie
-            sie jedoch zur Aus&uuml;bung, Verteidigung oder Geltendmachung von
-            Rechtsanspr&uuml;chen ben&ouml;tigen, haben Sie das Recht, statt der
-            L&ouml;schung die Einschr&auml;nkung der Verarbeitung Ihrer
-            personenbezogenen Daten zu verlangen.
-          </Text>
-        </li>
-        <li>
-          <Text>
-            Wenn Sie einen Widerspruch nach Art. 21 Abs. 1 DSGVO eingelegt
-            haben, muss eine Abw&auml;gung zwischen Ihren und unseren Interessen
-            vorgenommen werden. Solange noch nicht feststeht, wessen Interessen
-            &uuml;berwiegen, haben Sie das Recht, die Einschr&auml;nkung der
-            Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
-          </Text>
-        </li>
-      </ul>
-      <Text>
-        Wenn Sie die Verarbeitung Ihrer personenbezogenen Daten
-        eingeschr&auml;nkt haben, d&uuml;rfen diese Daten &ndash; von ihrer
-        Speicherung abgesehen &ndash; nur mit Ihrer Einwilligung oder zur
-        Geltendmachung, Aus&uuml;bung oder Verteidigung von
-        Rechtsanspr&uuml;chen oder zum Schutz der Rechte einer anderen
-        nat&uuml;rlichen oder juristischen Person oder aus Gr&uuml;nden eines
-        wichtigen &ouml;ffentlichen Interesses der Europ&auml;ischen Union oder
-        eines Mitgliedstaats verarbeitet werden.
-      </Text>
-      <Heading size="sm" as="h3">
-        SSL- bzw. TLS-Verschl&uuml;sselung
-      </Heading>
-      <Text>
-        Diese Seite nutzt aus Sicherheitsgr&uuml;nden und zum Schutz der
-        &Uuml;bertragung vertraulicher Inhalte, wie zum Beispiel Bestellungen
-        oder Anfragen, die Sie an uns als Seitenbetreiber senden, eine SSL- bzw.
-        TLS-Verschl&uuml;sselung. Eine verschl&uuml;sselte Verbindung erkennen
-        Sie daran, dass die Adresszeile des Browsers von &bdquo;http://&ldquo;
-        auf &bdquo;https://&ldquo; wechselt und an dem Schloss-Symbol in Ihrer
-        Browserzeile.
-      </Text>
-      <Text>
-        Wenn die SSL- bzw. TLS-Verschl&uuml;sselung aktiviert ist, k&ouml;nnen
-        die Daten, die Sie an uns &uuml;bermitteln, nicht von Dritten mitgelesen
-        werden.
-      </Text>
-      <Text>
-        Quelle:
-        <Text as="a" href="https://www.e-recht24.de">
-          eRecht24
+      <Stack direction="column" gap="16px">
+        <Link as={GatsbyLink} to="/">
+          <Stack gap="8px" align="center">
+            <FontAwesomeIcon size="lg" color="grey" icon={faChevronLeft} />
+            <Text css={{ fontSize: '16px' }}>Zurück</Text>
+          </Stack>
+        </Link>
+        <Heading size="md" as="h1" css={{ fontWeight: 800, fontSize: '20px' }}>
+          Datenschutz&shy;erkl&auml;rung
+        </Heading>
+        <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
+          1. Datenschutz auf einen Blick
+        </Heading>
+        <Heading size="sm" as="h3">
+          Allgemeine Hinweise
+        </Heading>
+        <Text>
+          Die folgenden Hinweise geben einen einfachen &Uuml;berblick
+          dar&uuml;ber, was mit Ihren personenbezogenen Daten passiert, wenn Sie
+          diese Website besuchen. Personenbezogene Daten sind alle Daten, mit
+          denen Sie pers&ouml;nlich identifiziert werden k&ouml;nnen.
+          Ausf&uuml;hrliche Informationen zum Thema Datenschutz entnehmen Sie
+          unserer unter diesem Text aufgef&uuml;hrten Datenschutzerkl&auml;rung.
         </Text>
-      </Text>
-      <Footer css={{ marginTop: '2rem' }}>
+        <Heading size="sm" as="h3">
+          Datenerfassung auf dieser Website
+        </Heading>
+        <Heading size="xs" as="h4">
+          Wer ist verantwortlich f&uuml;r die Datenerfassung auf dieser Website?
+        </Heading>
+        <Text>
+          Die Datenverarbeitung auf dieser Website erfolgt durch den
+          Websitebetreiber. Dessen Kontaktdaten k&ouml;nnen Sie dem Abschnitt
+          &bdquo;Hinweis zur Verantwortlichen Stelle&ldquo; in dieser
+          Datenschutzerkl&auml;rung entnehmen.
+        </Text>
+        <Heading size="xs" as="h4">
+          Wie erfassen wir Ihre Daten?
+        </Heading>
+        <Text>
+          Ihre Daten werden zum einen dadurch erhoben, dass Sie uns diese
+          mitteilen. Hierbei kann es sich z.&nbsp;B. um Daten handeln, die Sie
+          in ein Kontaktformular eingeben.
+        </Text>
+        <Text>
+          Andere Daten werden automatisch oder nach Ihrer Einwilligung beim
+          Besuch der Website durch unsere IT-Systeme erfasst. Das sind vor allem
+          technische Daten (z.&nbsp;B. Internetbrowser, Betriebssystem oder
+          Uhrzeit des Seitenaufrufs). Die Erfassung dieser Daten erfolgt
+          automatisch, sobald Sie diese Website betreten.
+        </Text>
+        <Heading size="xs" as="h4">
+          Wof&uuml;r nutzen wir Ihre Daten?
+        </Heading>
+        <Text>
+          Ein Teil der Daten wird erhoben, um eine fehlerfreie Bereitstellung
+          der Website zu gew&auml;hrleisten. Andere Daten k&ouml;nnen zur
+          Analyse Ihres Nutzerverhaltens verwendet werden.
+        </Text>
+        <Heading size="xs" as="h4">
+          Welche Rechte haben Sie bez&uuml;glich Ihrer Daten?
+        </Heading>
+        <Text>
+          Sie haben jederzeit das Recht, unentgeltlich Auskunft &uuml;ber
+          Herkunft, Empf&auml;nger und Zweck Ihrer gespeicherten
+          personenbezogenen Daten zu erhalten. Sie haben au&szlig;erdem ein
+          Recht, die Berichtigung oder L&ouml;schung dieser Daten zu verlangen.
+          Wenn Sie eine Einwilligung zur Datenverarbeitung erteilt haben,
+          k&ouml;nnen Sie diese Einwilligung jederzeit f&uuml;r die Zukunft
+          widerrufen. Au&szlig;erdem haben Sie das Recht, unter bestimmten
+          Umst&auml;nden die Einschr&auml;nkung der Verarbeitung Ihrer
+          personenbezogenen Daten zu verlangen. Des Weiteren steht Ihnen ein
+          Beschwerderecht bei der zust&auml;ndigen Aufsichtsbeh&ouml;rde zu.
+        </Text>
+        <Text>
+          Hierzu sowie zu weiteren Fragen zum Thema Datenschutz k&ouml;nnen Sie
+          sich jederzeit an uns wenden.
+        </Text>
+        <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
+          2. Hosting
+        </Heading>
+        <Text>
+          Wir hosten die Inhalte unserer Website bei folgendem Anbieter:
+        </Text>
+        <Heading size="sm" as="h3">
+          Externes Hosting
+        </Heading>
+        <Text>
+          Diese Website wird extern gehostet. Die personenbezogenen Daten, die
+          auf dieser Website erfasst werden, werden auf den Servern des Hosters
+          / der Hoster gespeichert. Hierbei kann es sich v.&nbsp;a. um
+          IP-Adressen, Kontaktanfragen, Meta- und Kommunikationsdaten,
+          Vertragsdaten, Kontaktdaten, Namen, Websitezugriffe und sonstige
+          Daten, die &uuml;ber eine Website generiert werden, handeln.
+        </Text>
+        <Text>
+          Das externe Hosting erfolgt zum Zwecke der Vertragserf&uuml;llung
+          gegen&uuml;ber unseren potenziellen und bestehenden Kunden (Art. 6
+          Abs. 1 lit. b DSGVO) und im Interesse einer sicheren, schnellen und
+          effizienten Bereitstellung unseres Online-Angebots durch einen
+          professionellen Anbieter (Art. 6 Abs. 1 lit. f DSGVO). Sofern eine
+          entsprechende Einwilligung abgefragt wurde, erfolgt die Verarbeitung
+          ausschlie&szlig;lich auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO und
+          &sect; 25 Abs. 1 TTDSG, soweit die Einwilligung die Speicherung von
+          Cookies oder den Zugriff auf Informationen im Endger&auml;t des
+          Nutzers (z.&nbsp;B. Device-Fingerprinting) im Sinne des TTDSG umfasst.
+          Die Einwilligung ist jederzeit widerrufbar.
+        </Text>
+        <Text>
+          Unser(e) Hoster wird bzw. werden Ihre Daten nur insoweit verarbeiten,
+          wie dies zur Erf&uuml;llung seiner Leistungspflichten erforderlich ist
+          und unsere Weisungen in Bezug auf diese Daten befolgen.
+        </Text>
+        <Text>Wir setzen folgende(n) Hoster ein:</Text>
+        <Text>
+          GitHub, Inc.
+          <br />
+          88 Colin P Kelly Jr Street <br />
+          San Francisco, CA 94107 <br />
+          United States
+        </Text>
+        <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
+          3. Allgemeine Hinweise und Pflicht&shy;informationen
+        </Heading>
+        <Heading size="sm" as="h3">
+          Datenschutz
+        </Heading>
+        <Text>
+          Die Betreiber dieser Seiten nehmen den Schutz Ihrer pers&ouml;nlichen
+          Daten sehr ernst. Wir behandeln Ihre personenbezogenen Daten
+          vertraulich und entsprechend den gesetzlichen Datenschutzvorschriften
+          sowie dieser Datenschutzerkl&auml;rung.
+        </Text>
+        <Text>
+          Wenn Sie diese Website benutzen, werden verschiedene personenbezogene
+          Daten erhoben. Personenbezogene Daten sind Daten, mit denen Sie
+          pers&ouml;nlich identifiziert werden k&ouml;nnen. Die vorliegende
+          Datenschutzerkl&auml;rung erl&auml;utert, welche Daten wir erheben und
+          wof&uuml;r wir sie nutzen. Sie erl&auml;utert auch, wie und zu welchem
+          Zweck das geschieht.
+        </Text>
+        <Text>
+          Wir weisen darauf hin, dass die Daten&uuml;bertragung im Internet
+          (z.&nbsp;B. bei der Kommunikation per E-Mail) Sicherheitsl&uuml;cken
+          aufweisen kann. Ein l&uuml;ckenloser Schutz der Daten vor dem Zugriff
+          durch Dritte ist nicht m&ouml;glich.
+        </Text>
+        <Heading size="sm" as="h3">
+          Hinweis zur verantwortlichen Stelle
+        </Heading>
+        <Text>
+          Die verantwortliche Stelle f&uuml;r die Datenverarbeitung auf dieser
+          Website ist:
+        </Text>
+        <Text>
+          {name}
+          <br />
+          {address.street}
+          <br />
+          {address.zip} {address.city}
+        </Text>
+        <Text>
+          Telefon: {phone}
+          <br />
+          E-Mail: {email}
+        </Text>
+        <Text>
+          Verantwortliche Stelle ist die nat&uuml;rliche oder juristische
+          Person, die allein oder gemeinsam mit anderen &uuml;ber die Zwecke und
+          Mittel der Verarbeitung von personenbezogenen Daten (z.&nbsp;B. Namen,
+          E-Mail-Adressen o. &Auml;.) entscheidet.
+        </Text>
+        <Heading size="sm" as="h3">
+          Speicherdauer
+        </Heading>
+        <Text>
+          Soweit innerhalb dieser Datenschutzerkl&auml;rung keine speziellere
+          Speicherdauer genannt wurde, verbleiben Ihre personenbezogenen Daten
+          bei uns, bis der Zweck f&uuml;r die Datenverarbeitung entf&auml;llt.
+          Wenn Sie ein berechtigtes L&ouml;schersuchen geltend machen oder eine
+          Einwilligung zur Datenverarbeitung widerrufen, werden Ihre Daten
+          gel&ouml;scht, sofern wir keine anderen rechtlich zul&auml;ssigen
+          Gr&uuml;nde f&uuml;r die Speicherung Ihrer personenbezogenen Daten
+          haben (z.&nbsp;B. steuer- oder handelsrechtliche
+          Aufbewahrungsfristen); im letztgenannten Fall erfolgt die
+          L&ouml;schung nach Fortfall dieser Gr&uuml;nde.
+        </Text>
+        <Heading size="sm" as="h3">
+          Allgemeine Hinweise zu den Rechtsgrundlagen der Datenverarbeitung auf
+          dieser Website
+        </Heading>
+        <Text>
+          Sofern Sie in die Datenverarbeitung eingewilligt haben, verarbeiten
+          wir Ihre personenbezogenen Daten auf Grundlage von Art. 6 Abs. 1 lit.
+          a DSGVO bzw. Art. 9 Abs. 2 lit. a DSGVO, sofern besondere
+          Datenkategorien nach Art. 9 Abs. 1 DSGVO verarbeitet werden. Im Falle
+          einer ausdr&uuml;cklichen Einwilligung in die &Uuml;bertragung
+          personenbezogener Daten in Drittstaaten erfolgt die Datenverarbeitung
+          au&szlig;erdem auf Grundlage von Art. 49 Abs. 1 lit. a DSGVO. Sofern
+          Sie in die Speicherung von Cookies oder in den Zugriff auf
+          Informationen in Ihr Endger&auml;t (z.&nbsp;B. via
+          Device-Fingerprinting) eingewilligt haben, erfolgt die
+          Datenverarbeitung zus&auml;tzlich auf Grundlage von &sect; 25 Abs. 1
+          TTDSG. Die Einwilligung ist jederzeit widerrufbar. Sind Ihre Daten zur
+          Vertragserf&uuml;llung oder zur Durchf&uuml;hrung vorvertraglicher
+          Ma&szlig;nahmen erforderlich, verarbeiten wir Ihre Daten auf Grundlage
+          des Art. 6 Abs. 1 lit. b DSGVO. Des Weiteren verarbeiten wir Ihre
+          Daten, sofern diese zur Erf&uuml;llung einer rechtlichen Verpflichtung
+          erforderlich sind auf Grundlage von Art. 6 Abs. 1 lit. c DSGVO. Die
+          Datenverarbeitung kann ferner auf Grundlage unseres berechtigten
+          Interesses nach Art. 6 Abs. 1 lit. f DSGVO erfolgen. &Uuml;ber die
+          jeweils im Einzelfall einschl&auml;gigen Rechtsgrundlagen wird in den
+          folgenden Abs&auml;tzen dieser Datenschutzerkl&auml;rung informiert.
+        </Text>
+        <Heading size="sm" as="h3">
+          Widerruf Ihrer Einwilligung zur Datenverarbeitung
+        </Heading>
+        <Text>
+          Viele Datenverarbeitungsvorg&auml;nge sind nur mit Ihrer
+          ausdr&uuml;cklichen Einwilligung m&ouml;glich. Sie k&ouml;nnen eine
+          bereits erteilte Einwilligung jederzeit widerrufen. Die
+          Rechtm&auml;&szlig;igkeit der bis zum Widerruf erfolgten
+          Datenverarbeitung bleibt vom Widerruf unber&uuml;hrt.
+        </Text>
+        <Heading size="sm" as="h3">
+          Widerspruchsrecht gegen die Datenerhebung in besonderen F&auml;llen
+          sowie gegen Direktwerbung (Art. 21 DSGVO)
+        </Heading>
+        <Text>
+          WENN DIE DATENVERARBEITUNG AUF GRUNDLAGE VON ART. 6 ABS. 1 LIT. E ODER
+          F DSGVO ERFOLGT, HABEN SIE JEDERZEIT DAS RECHT, AUS GR&Uuml;NDEN, DIE
+          SICH AUS IHRER BESONDEREN SITUATION ERGEBEN, GEGEN DIE VERARBEITUNG
+          IHRER PERSONENBEZOGENEN DATEN WIDERSPRUCH EINZULEGEN; DIES GILT AUCH
+          F&Uuml;R EIN AUF DIESE BESTIMMUNGEN GEST&Uuml;TZTES PROFILING. DIE
+          JEWEILIGE RECHTSGRUNDLAGE, AUF DENEN EINE VERARBEITUNG BERUHT,
+          ENTNEHMEN SIE DIESER DATENSCHUTZERKL&Auml;RUNG. WENN SIE WIDERSPRUCH
+          EINLEGEN, WERDEN WIR IHRE BETROFFENEN PERSONENBEZOGENEN DATEN NICHT
+          MEHR VERARBEITEN, ES SEI DENN, WIR K&Ouml;NNEN ZWINGENDE
+          SCHUTZW&Uuml;RDIGE GR&Uuml;NDE F&Uuml;R DIE VERARBEITUNG NACHWEISEN,
+          DIE IHRE INTERESSEN, RECHTE UND FREIHEITEN &Uuml;BERWIEGEN ODER DIE
+          VERARBEITUNG DIENT DER GELTENDMACHUNG, AUS&Uuml;BUNG ODER VERTEIDIGUNG
+          VON RECHTSANSPR&Uuml;CHEN (WIDERSPRUCH NACH ART. 21 ABS. 1 DSGVO).
+        </Text>
+        <Text>
+          WERDEN IHRE PERSONENBEZOGENEN DATEN VERARBEITET, UM DIREKTWERBUNG ZU
+          BETREIBEN, SO HABEN SIE DAS RECHT, JEDERZEIT WIDERSPRUCH GEGEN DIE
+          VERARBEITUNG SIE BETREFFENDER PERSONENBEZOGENER DATEN ZUM ZWECKE
+          DERARTIGER WERBUNG EINZULEGEN; DIES GILT AUCH F&Uuml;R DAS PROFILING,
+          SOWEIT ES MIT SOLCHER DIREKTWERBUNG IN VERBINDUNG STEHT. WENN SIE
+          WIDERSPRECHEN, WERDEN IHRE PERSONENBEZOGENEN DATEN ANSCHLIESSEND NICHT
+          MEHR ZUM ZWECKE DER DIREKTWERBUNG VERWENDET (WIDERSPRUCH NACH ART. 21
+          ABS. 2 DSGVO).
+        </Text>
+        <Heading size="sm" as="h3">
+          Beschwerde&shy;recht bei der zust&auml;ndigen
+          Aufsichts&shy;beh&ouml;rde
+        </Heading>
+        <Text>
+          Im Falle von Verst&ouml;&szlig;en gegen die DSGVO steht den
+          Betroffenen ein Beschwerderecht bei einer Aufsichtsbeh&ouml;rde,
+          insbesondere in dem Mitgliedstaat ihres gew&ouml;hnlichen Aufenthalts,
+          ihres Arbeitsplatzes oder des Orts des mutma&szlig;lichen
+          Versto&szlig;es zu. Das Beschwerderecht besteht unbeschadet
+          anderweitiger verwaltungsrechtlicher oder gerichtlicher Rechtsbehelfe.
+        </Text>
+        <Heading size="sm" as="h3">
+          Recht auf Daten&shy;&uuml;bertrag&shy;barkeit
+        </Heading>
+        <Text>
+          Sie haben das Recht, Daten, die wir auf Grundlage Ihrer Einwilligung
+          oder in Erf&uuml;llung eines Vertrags automatisiert verarbeiten, an
+          sich oder an einen Dritten in einem g&auml;ngigen, maschinenlesbaren
+          Format aush&auml;ndigen zu lassen. Sofern Sie die direkte
+          &Uuml;bertragung der Daten an einen anderen Verantwortlichen
+          verlangen, erfolgt dies nur, soweit es technisch machbar ist.
+        </Text>
+        <Heading size="sm" as="h3">
+          Auskunft, Berichtigung und L&ouml;schung
+        </Heading>
+        <Text>
+          Sie haben im Rahmen der geltenden gesetzlichen Bestimmungen jederzeit
+          das Recht auf unentgeltliche Auskunft &uuml;ber Ihre gespeicherten
+          personenbezogenen Daten, deren Herkunft und Empf&auml;nger und den
+          Zweck der Datenverarbeitung und ggf. ein Recht auf Berichtigung oder
+          L&ouml;schung dieser Daten. Hierzu sowie zu weiteren Fragen zum Thema
+          personenbezogene Daten k&ouml;nnen Sie sich jederzeit an uns wenden.
+        </Text>
+        <Heading size="sm" as="h3">
+          Recht auf Einschr&auml;nkung der Verarbeitung
+        </Heading>
+        <Text>
+          Sie haben das Recht, die Einschr&auml;nkung der Verarbeitung Ihrer
+          personenbezogenen Daten zu verlangen. Hierzu k&ouml;nnen Sie sich
+          jederzeit an uns wenden. Das Recht auf Einschr&auml;nkung der
+          Verarbeitung besteht in folgenden F&auml;llen:
+        </Text>
+        <ul>
+          <li>
+            <Text>
+              Wenn Sie die Richtigkeit Ihrer bei uns gespeicherten
+              personenbezogenen Daten bestreiten, ben&ouml;tigen wir in der
+              Regel Zeit, um dies zu &uuml;berpr&uuml;fen. F&uuml;r die Dauer
+              der Pr&uuml;fung haben Sie das Recht, die Einschr&auml;nkung der
+              Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
+            </Text>
+          </li>
+          <li>
+            <Text>
+              Wenn die Verarbeitung Ihrer personenbezogenen Daten
+              unrechtm&auml;&szlig;ig geschah/geschieht, k&ouml;nnen Sie statt
+              der L&ouml;schung die Einschr&auml;nkung der Datenverarbeitung
+              verlangen.
+            </Text>
+          </li>
+          <li>
+            <Text>
+              Wenn wir Ihre personenbezogenen Daten nicht mehr ben&ouml;tigen,
+              Sie sie jedoch zur Aus&uuml;bung, Verteidigung oder Geltendmachung
+              von Rechtsanspr&uuml;chen ben&ouml;tigen, haben Sie das Recht,
+              statt der L&ouml;schung die Einschr&auml;nkung der Verarbeitung
+              Ihrer personenbezogenen Daten zu verlangen.
+            </Text>
+          </li>
+          <li>
+            <Text>
+              Wenn Sie einen Widerspruch nach Art. 21 Abs. 1 DSGVO eingelegt
+              haben, muss eine Abw&auml;gung zwischen Ihren und unseren
+              Interessen vorgenommen werden. Solange noch nicht feststeht,
+              wessen Interessen &uuml;berwiegen, haben Sie das Recht, die
+              Einschr&auml;nkung der Verarbeitung Ihrer personenbezogenen Daten
+              zu verlangen.
+            </Text>
+          </li>
+        </ul>
+        <Text>
+          Wenn Sie die Verarbeitung Ihrer personenbezogenen Daten
+          eingeschr&auml;nkt haben, d&uuml;rfen diese Daten &ndash; von ihrer
+          Speicherung abgesehen &ndash; nur mit Ihrer Einwilligung oder zur
+          Geltendmachung, Aus&uuml;bung oder Verteidigung von
+          Rechtsanspr&uuml;chen oder zum Schutz der Rechte einer anderen
+          nat&uuml;rlichen oder juristischen Person oder aus Gr&uuml;nden eines
+          wichtigen &ouml;ffentlichen Interesses der Europ&auml;ischen Union
+          oder eines Mitgliedstaats verarbeitet werden.
+        </Text>
+        <Heading size="sm" as="h3">
+          SSL- bzw. TLS-Verschl&uuml;sselung
+        </Heading>
+        <Text>
+          Diese Seite nutzt aus Sicherheitsgr&uuml;nden und zum Schutz der
+          &Uuml;bertragung vertraulicher Inhalte, wie zum Beispiel Bestellungen
+          oder Anfragen, die Sie an uns als Seitenbetreiber senden, eine SSL-
+          bzw. TLS-Verschl&uuml;sselung. Eine verschl&uuml;sselte Verbindung
+          erkennen Sie daran, dass die Adresszeile des Browsers von
+          &bdquo;http://&ldquo; auf &bdquo;https://&ldquo; wechselt und an dem
+          Schloss-Symbol in Ihrer Browserzeile.
+        </Text>
+        <Text>
+          Wenn die SSL- bzw. TLS-Verschl&uuml;sselung aktiviert ist, k&ouml;nnen
+          die Daten, die Sie an uns &uuml;bermitteln, nicht von Dritten
+          mitgelesen werden.
+        </Text>
+        <Text>
+          Quelle:
+          <Text as="a" href="https://www.e-recht24.de">
+            eRecht24
+          </Text>
+        </Text>
+      </Stack>
+      <Footer css={{ marginTop: '2rem', paddingBottom: '2.5rem' }}>
         <Link as={GatsbyLink} to="/">
           CV
         </Link>

--- a/src/pages/privacy-en.tsx
+++ b/src/pages/privacy-en.tsx
@@ -15,340 +15,350 @@ const Privacy = () => {
   return (
     <Stack
       direction="column"
+      justify="space-between"
       gap="16px"
-      css={{ paddingTop: '3rem', marginInline: '4rem', marginBottom: '2.5rem' }}
+      css={{
+        paddingTop: '3rem',
+        marginInline: '4rem',
+        height: 'calc(100vh - 5.5rem)',
+      }}
     >
-      <Link as={GatsbyLink} to="/">
-        <Stack gap="8px" align="center">
-          <FontAwesomeIcon size="lg" color="grey" icon={faChevronLeft} />
-          <Text css={{ fontSize: '16px' }}>Back</Text>
-        </Stack>
-      </Link>
-      <Heading size="md" as="h1" css={{ fontWeight: 800, fontSize: '20px' }}>
-        Data Protection
-      </Heading>
-      <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
-        1. Data protection overview
-      </Heading>
-      <Heading size="sm" as="h3">
-        General notes
-      </Heading>
-      <Text>
-        The following notices provide a simple overview of what happens to your
-        personal data when you visit this website. Personal data is any data by
-        which you can be personally identified. For detailed information on the
-        subject of data protection, please refer to our privacy policy listed
-        below this text.
-      </Text>
-      <Heading size="sm" as="h3">
-        Data collection on this website
-      </Heading>
-      <Heading size="xs" as="h4">
-        Who is responsible for the data collection on this website?
-      </Heading>
-      <Text>
-        Data processing on this website is carried out by the website operator.
-        You can find the contact details of the website operator in the section
-        &quot;Information about the responsible party&quot; in this data
-        protection declaration.
-      </Text>
-      <Heading size="xs" as="h4">
-        How do we collect your data?
-      </Heading>
-      <Text>
-        On the one hand, your data is collected when you provide it to us. This
-        can be, for example, data that you enter in a contact form.
-      </Text>
-      <Text>
-        Other data is collected automatically or after your consent when you
-        visit the website by our IT systems. This is mainly technical data (e.g.
-        Internet browser, operating system or time of page view). The collection
-        of this data takes place automatically as soon as you enter this
-        website.
-      </Text>
-      <Heading size="xs" as="h4">
-        What do we use your data for?
-      </Heading>
-      <Text>
-        Some of the data is collected to ensure error-free provision of the
-        website. Other data may be used to analyze your user behavior.
-      </Text>
-      <Heading size="xs" as="h4">
-        What rights do you have regarding your data?
-      </Heading>
-      <Text>
-        You have the right at any time to receive information free of charge
-        about the origin, recipient and purpose of your stored personal data.
-        You also have a right to request the correction or deletion of this
-        data. If you have given your consent to data processing, you can revoke
-        this consent at any time for the future. You also have the right to
-        request the restriction of the processing of your personal data under
-        certain circumstances. Furthermore, you have the right to lodge a
-        complaint with the competent supervisory authority.
-      </Text>
-      <Text>
-        For this purpose, as well as for further questions on the subject of
-        data protection, you can contact us at any time.
-      </Text>
-      <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
-        2. Hosting
-      </Heading>
-      <Text>
-        We host the content of our website with the following provider:
-      </Text>
-      <Heading size="sm" as="h3">
-        External Hosting
-      </Heading>
-      <Text>
-        This website is hosted externally. The personal data collected on this
-        website is stored on the servers of the hoster(s). This may include, but
-        is not limited to, IP addresses, contact requests, meta and
-        communication data, contractual data, contact details, names, website
-        accesses and other data generated via a website.
-      </Text>
-      <Text>
-        External hosting is carried out for the purpose of contract fulfillment
-        vis-à-vis our potential and existing customers (Art. 6 para. 1 lit. b
-        DSGVO) and in the interest of a secure, fast and efficient provision of
-        our online offer by a professional provider (Art. 6 para. 1 lit. f
-        DSGVO). Insofar as a corresponding consent has been requested, the
-        processing is carried out exclusively on the basis of Art. 6 para. 1
-        lit. a DSGVO and § 25 para. 1 TTDSG, insofar as the consent includes the
-        storage of cookies or access to information in the user`&apos;`s
-        terminal device (e.g. device fingerprinting) as defined by the TTDSG.
-        The consent can be revoked at any time.
-      </Text>
-      <Text>
-        Our hoster will only process your data to the extent necessary to
-        fulfill their service obligations and follow our instructions regarding
-        this data.
-      </Text>
-      <Text>We use the following hoster:</Text>
-      <Text>
-        GitHub, Inc.
-        <br />
-        88 Colin P Kelly Jr Street <br />
-        San Francisco, CA 94107 <br />
-        United States
-      </Text>
-      <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
-        3. General notes and mandatory information
-      </Heading>
-      <Heading size="sm" as="h3">
-        Data Protection
-      </Heading>
-      <Text>
-        The operators of these pages take the protection of your personal data
-        very seriously. We treat your personal data confidentially and in
-        accordance with the statutory data protection regulations and this
-        privacy policy.
-      </Text>
-      <Text>
-        When you use this website, various personal data are collected. Personal
-        data is data with which you can be personally identified. This privacy
-        policy explains what data we collect and what we use it for. It also
-        explains how and for what purpose this is done.
-      </Text>
-      <Text>
-        We would like to point out that data transmission on the Internet (e.g.
-        when communicating by e-mail) can have security gaps. Complete
-        protection of data against access by third parties is not possible.
-      </Text>
-      <Heading size="sm" as="h3">
-        Note on the responsible entity
-      </Heading>
-      <Text>The responsible party for data processing on this website is:</Text>
-      <Text>
-        {name}
-        <br />
-        {address.street}
-        <br />
-        {address.zip} {address.city}
-      </Text>
-      <Text>
-        Phone: {phone}
-        <br />
-        E-mail: {email}
-      </Text>
-      <Text>
-        The responsible party is the natural or legal person who alone or
-        jointly with others determines the purposes and means of the processing
-        of personal data (e.g. names, e-mail addresses, etc.).
-      </Text>
-      <Heading size="sm" as="h3">
-        Speicherdauer
-      </Heading>
-      <Text>
-        Unless a more specific storage period has been specified within this
-        privacy policy, your personal data will remain with us until the purpose
-        for data processing no longer applies. If you assert a legitimate
-        request for deletion or revoke your consent to data processing, your
-        data will be deleted unless we have other legally permissible reasons
-        for storing your personal data (e.g. retention periods under tax or
-        commercial law); in the latter case, the data will be deleted once these
-        reasons no longer apply.
-      </Text>
-      <Heading size="sm" as="h3">
-        General information about the legal basis of data processing on this
-        website
-      </Heading>
-      <Text>
-        If you have consented to data processing, we process your personal data
-        on the basis of Art. 6 (1) a DSGVO or Art. 9 (2) a DSGVO, if special
-        categories of data are processed according to Art. 9 (1) DSGVO. In the
-        case of explicit consent to the transfer of personal data to third
-        countries, the data processing is also based on Art. 49 (1) a DSGVO. If
-        you have consented to the storage of cookies or to the access to
-        information in your terminal device (e.g. via device fingerprinting),
-        the data processing is additionally carried out on the basis of Section
-        25 (1) TTDSG. The consent can be revoked at any time. If your data is
-        required for the performance of a contract or for the implementation of
-        pre-contractual measures, we process your data on the basis of Art. 6
-        para. 1 lit. b DSGVO. Furthermore, if your data is required for the
-        fulfillment of a legal obligation, we process it on the basis of Art. 6
-        para. 1 lit. c DSGVO. Furthermore, the data processing may be carried
-        out on the basis of our legitimate interest according to Art. 6 para. 1
-        lit. f DSGVO. Information about the relevant legal basis in each
-        individual case is provided in the following paragraphs of this privacy
-        policy.
-      </Text>
-      <Heading size="sm" as="h3">
-        Revoking your consent to data processing
-      </Heading>
-      <Text>
-        Many data processing operations are only possible with your express
-        consent. You can revoke consent you have already given at any time. The
-        legality of the data processing carried out until the revocation remains
-        unaffected by the revocation.
-      </Text>
-      <Heading size="sm" as="h3">
-        Right to object to data collection in special cases and to direct
-        marketing (Art. 21 DSGVO)
-      </Heading>
-      <Text>
-        IF THE DATA PROCESSING IS CARRIED OUT ON THE BASIS OF ART. 6 ABS. 1 LIT.
-        E OR F DSGVO, YOU HAVE THE RIGHT TO OBJECT TO THE PROCESSING OF YOUR
-        PERSONAL DATA AT ANY TIME FOR REASONS ARISING FROM YOUR PARTICULAR
-        SITUATION; THIS ALSO APPLIES TO PROFILING BASED ON THESE PROVISIONS. THE
-        RESPECTIVE LEGAL BASIS ON WHICH PROCESSING IS BASED CAN BE FOUND IN THIS
-        PRIVACY POLICY. IF YOU OBJECT, WE WILL NO LONGER PROCESS YOUR PERSONAL
-        DATA CONCERNED UNLESS WE CAN DEMONSTRATE COMPELLING LEGITIMATE GROUNDS
-        FOR THE PROCESSING WHICH OVERRIDE YOUR INTERESTS, RIGHTS AND FREEDOMS,
-        OR THE PROCESSING IS FOR THE PURPOSE OF ASSERTING, EXERCISING OR
-        DEFENDING LEGAL CLAIMS (OBJECTION UNDER ARTICLE 21(1) DSGVO).
-      </Text>
-      <Text>
-        IF YOUR PERSONAL DATA ARE PROCESSED FOR THE PURPOSE OF DIRECT MARKETING,
-        YOU HAVE THE RIGHT TO OBJECT AT ANY TIME TO THE PROCESSING OF PERSONAL
-        DATA CONCERNING YOU FOR THE PURPOSE OF SUCH MARKETING; THIS ALSO APPLIES
-        TO PROFILING INSOFAR AS IT IS RELATED TO SUCH DIRECT MARKETING. IF YOU
-        OBJECT, YOUR PERSONAL DATA WILL SUBSEQUENTLY NO LONGER BE USED FOR THE
-        PURPOSE OF DIRECT MARKETING (OBJECTION PURSUANT TO ARTICLE 21 (2)
-        DSGVO).
-      </Text>
-      <Heading size="sm" as="h3">
-        Right of appeal to the competent supervisory authority
-      </Heading>
-      <Text>
-        In the event of breaches of the GDPR, data subjects shall have a right
-        of appeal to a supervisory authority, in particular in the Member State
-        of their habitual residence, their place of work or the place of the
-        alleged breach. The right of appeal is without prejudice to other
-        administrative or judicial remedies.
-      </Text>
-      <Heading size="sm" as="h3">
-        Right to data portability
-      </Heading>
-      <Text>
-        You have the right to have data that we process automatically on the
-        basis of your consent or in fulfillment of a contract handed over to you
-        or to a third party in a common, machine-readable format. If you request
-        the direct transfer of the data to another controller, this will only be
-        done insofar as it is technically feasible.
-      </Text>
-      <Heading size="sm" as="h3">
-        Information, correction and deletion
-      </Heading>
-      <Text>
-        Within the framework of the applicable legal provisions, you have the
-        right at any time to free information about your stored personal data,
-        its origin and recipient and the purpose of data processing and, if
-        necessary, a right to correction or deletion of this data. For this
-        purpose, as well as for further questions on the subject of personal
-        data, you can contact us at any time.
-      </Text>
-      <Heading size="sm" as="h3">
-        Right to restriction of processing
-      </Heading>
-      <Text>
-        You have the right to request the restriction of the processing of your
-        personal data. For this purpose, you can contact us at any time. The
-        right to restriction of processing exists in the following cases:
-      </Text>
-      <ul>
-        <li>
-          <Text>
-            You have the right to request the restriction of the processing of
-            your personal data. For this purpose, you can contact us at any
-            time. The right to restriction of processing exists in the following
-            cases:
-          </Text>
-        </li>
-        <li>
-          <Text>
-            If the processing of your personal data happened/is happening
-            unlawfully, you may request the restriction of data processing
-            instead of erasure.
-          </Text>
-        </li>
-        <li>
-          <Text>
-            If we no longer need your personal data, but you need it to
-            exercise, defend or enforce legal claims, you have the right to
-            request restriction of the processing of your personal data instead
-            of deletion.
-          </Text>
-        </li>
-        <li>
-          <Text>
-            If you have lodged an objection pursuant to Art. 21 (1) DSGVO, a
-            balancing of your and our interests must be carried out. As long as
-            it has not yet been determined whose interests prevail, you have the
-            right to request the restriction of the processing of your personal
-            data.
-          </Text>
-        </li>
-      </ul>
-      <Text>
-        If you have restricted the processing of your personal data, this data
-        may - apart from being stored - only be processed with your consent or
-        for the assertion, exercise or defense of legal claims or for the
-        protection of the rights of another natural or legal person or for
-        reasons of an important public interest of the European Union or a
-        Member State.
-      </Text>
-      <Heading size="sm" as="h3">
-        SSL or TLS encryption
-      </Heading>
-      <Text>
-        This site uses SSL or TLS encryption for security reasons and to protect
-        the transmission of confidential content, such as orders or requests
-        that you send to us as the site operator. You can recognize an encrypted
-        connection by the fact that the address line of the browser changes from
-        `&quot;http://`&quot; to `&quot;https://`&quot; and by the lock symbol
-        in your browser line.
-      </Text>
-      <Text>
-        If SSL or TLS encryption is activated, the data you transmit to us
-        cannot be read by third parties.
-      </Text>
-      <Text>
-        Source:
-        <Text as="a" href="https://www.e-recht24.de">
-          eRecht24
+      <Stack direction="column" gap="16px">
+        <Link as={GatsbyLink} to="/">
+          <Stack gap="8px" align="center">
+            <FontAwesomeIcon size="lg" color="grey" icon={faChevronLeft} />
+            <Text css={{ fontSize: '16px' }}>Back</Text>
+          </Stack>
+        </Link>
+        <Heading size="md" as="h1" css={{ fontWeight: 800, fontSize: '20px' }}>
+          Data Protection
+        </Heading>
+        <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
+          1. Data protection overview
+        </Heading>
+        <Heading size="sm" as="h3">
+          General notes
+        </Heading>
+        <Text>
+          The following notices provide a simple overview of what happens to
+          your personal data when you visit this website. Personal data is any
+          data by which you can be personally identified. For detailed
+          information on the subject of data protection, please refer to our
+          privacy policy listed below this text.
         </Text>
-      </Text>
-      <Footer css={{ marginTop: '2rem' }}>
+        <Heading size="sm" as="h3">
+          Data collection on this website
+        </Heading>
+        <Heading size="xs" as="h4">
+          Who is responsible for the data collection on this website?
+        </Heading>
+        <Text>
+          Data processing on this website is carried out by the website
+          operator. You can find the contact details of the website operator in
+          the section &quot;Information about the responsible party&quot; in
+          this data protection declaration.
+        </Text>
+        <Heading size="xs" as="h4">
+          How do we collect your data?
+        </Heading>
+        <Text>
+          On the one hand, your data is collected when you provide it to us.
+          This can be, for example, data that you enter in a contact form.
+        </Text>
+        <Text>
+          Other data is collected automatically or after your consent when you
+          visit the website by our IT systems. This is mainly technical data
+          (e.g. Internet browser, operating system or time of page view). The
+          collection of this data takes place automatically as soon as you enter
+          this website.
+        </Text>
+        <Heading size="xs" as="h4">
+          What do we use your data for?
+        </Heading>
+        <Text>
+          Some of the data is collected to ensure error-free provision of the
+          website. Other data may be used to analyze your user behavior.
+        </Text>
+        <Heading size="xs" as="h4">
+          What rights do you have regarding your data?
+        </Heading>
+        <Text>
+          You have the right at any time to receive information free of charge
+          about the origin, recipient and purpose of your stored personal data.
+          You also have a right to request the correction or deletion of this
+          data. If you have given your consent to data processing, you can
+          revoke this consent at any time for the future. You also have the
+          right to request the restriction of the processing of your personal
+          data under certain circumstances. Furthermore, you have the right to
+          lodge a complaint with the competent supervisory authority.
+        </Text>
+        <Text>
+          For this purpose, as well as for further questions on the subject of
+          data protection, you can contact us at any time.
+        </Text>
+        <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
+          2. Hosting
+        </Heading>
+        <Text>
+          We host the content of our website with the following provider:
+        </Text>
+        <Heading size="sm" as="h3">
+          External Hosting
+        </Heading>
+        <Text>
+          This website is hosted externally. The personal data collected on this
+          website is stored on the servers of the hoster(s). This may include,
+          but is not limited to, IP addresses, contact requests, meta and
+          communication data, contractual data, contact details, names, website
+          accesses and other data generated via a website.
+        </Text>
+        <Text>
+          External hosting is carried out for the purpose of contract
+          fulfillment vis-à-vis our potential and existing customers (Art. 6
+          para. 1 lit. b DSGVO) and in the interest of a secure, fast and
+          efficient provision of our online offer by a professional provider
+          (Art. 6 para. 1 lit. f DSGVO). Insofar as a corresponding consent has
+          been requested, the processing is carried out exclusively on the basis
+          of Art. 6 para. 1 lit. a DSGVO and § 25 para. 1 TTDSG, insofar as the
+          consent includes the storage of cookies or access to information in
+          the user`&apos;`s terminal device (e.g. device fingerprinting) as
+          defined by the TTDSG. The consent can be revoked at any time.
+        </Text>
+        <Text>
+          Our hoster will only process your data to the extent necessary to
+          fulfill their service obligations and follow our instructions
+          regarding this data.
+        </Text>
+        <Text>We use the following hoster:</Text>
+        <Text>
+          GitHub, Inc.
+          <br />
+          88 Colin P Kelly Jr Street <br />
+          San Francisco, CA 94107 <br />
+          United States
+        </Text>
+        <Heading size="md" as="h2" css={{ letterSpacing: '3px' }}>
+          3. General notes and mandatory information
+        </Heading>
+        <Heading size="sm" as="h3">
+          Data Protection
+        </Heading>
+        <Text>
+          The operators of these pages take the protection of your personal data
+          very seriously. We treat your personal data confidentially and in
+          accordance with the statutory data protection regulations and this
+          privacy policy.
+        </Text>
+        <Text>
+          When you use this website, various personal data are collected.
+          Personal data is data with which you can be personally identified.
+          This privacy policy explains what data we collect and what we use it
+          for. It also explains how and for what purpose this is done.
+        </Text>
+        <Text>
+          We would like to point out that data transmission on the Internet
+          (e.g. when communicating by e-mail) can have security gaps. Complete
+          protection of data against access by third parties is not possible.
+        </Text>
+        <Heading size="sm" as="h3">
+          Note on the responsible entity
+        </Heading>
+        <Text>
+          The responsible party for data processing on this website is:
+        </Text>
+        <Text>
+          {name}
+          <br />
+          {address.street}
+          <br />
+          {address.zip} {address.city}
+        </Text>
+        <Text>
+          Phone: {phone}
+          <br />
+          E-mail: {email}
+        </Text>
+        <Text>
+          The responsible party is the natural or legal person who alone or
+          jointly with others determines the purposes and means of the
+          processing of personal data (e.g. names, e-mail addresses, etc.).
+        </Text>
+        <Heading size="sm" as="h3">
+          Speicherdauer
+        </Heading>
+        <Text>
+          Unless a more specific storage period has been specified within this
+          privacy policy, your personal data will remain with us until the
+          purpose for data processing no longer applies. If you assert a
+          legitimate request for deletion or revoke your consent to data
+          processing, your data will be deleted unless we have other legally
+          permissible reasons for storing your personal data (e.g. retention
+          periods under tax or commercial law); in the latter case, the data
+          will be deleted once these reasons no longer apply.
+        </Text>
+        <Heading size="sm" as="h3">
+          General information about the legal basis of data processing on this
+          website
+        </Heading>
+        <Text>
+          If you have consented to data processing, we process your personal
+          data on the basis of Art. 6 (1) a DSGVO or Art. 9 (2) a DSGVO, if
+          special categories of data are processed according to Art. 9 (1)
+          DSGVO. In the case of explicit consent to the transfer of personal
+          data to third countries, the data processing is also based on Art. 49
+          (1) a DSGVO. If you have consented to the storage of cookies or to the
+          access to information in your terminal device (e.g. via device
+          fingerprinting), the data processing is additionally carried out on
+          the basis of Section 25 (1) TTDSG. The consent can be revoked at any
+          time. If your data is required for the performance of a contract or
+          for the implementation of pre-contractual measures, we process your
+          data on the basis of Art. 6 para. 1 lit. b DSGVO. Furthermore, if your
+          data is required for the fulfillment of a legal obligation, we process
+          it on the basis of Art. 6 para. 1 lit. c DSGVO. Furthermore, the data
+          processing may be carried out on the basis of our legitimate interest
+          according to Art. 6 para. 1 lit. f DSGVO. Information about the
+          relevant legal basis in each individual case is provided in the
+          following paragraphs of this privacy policy.
+        </Text>
+        <Heading size="sm" as="h3">
+          Revoking your consent to data processing
+        </Heading>
+        <Text>
+          Many data processing operations are only possible with your express
+          consent. You can revoke consent you have already given at any time.
+          The legality of the data processing carried out until the revocation
+          remains unaffected by the revocation.
+        </Text>
+        <Heading size="sm" as="h3">
+          Right to object to data collection in special cases and to direct
+          marketing (Art. 21 DSGVO)
+        </Heading>
+        <Text>
+          IF THE DATA PROCESSING IS CARRIED OUT ON THE BASIS OF ART. 6 ABS. 1
+          LIT. E OR F DSGVO, YOU HAVE THE RIGHT TO OBJECT TO THE PROCESSING OF
+          YOUR PERSONAL DATA AT ANY TIME FOR REASONS ARISING FROM YOUR
+          PARTICULAR SITUATION; THIS ALSO APPLIES TO PROFILING BASED ON THESE
+          PROVISIONS. THE RESPECTIVE LEGAL BASIS ON WHICH PROCESSING IS BASED
+          CAN BE FOUND IN THIS PRIVACY POLICY. IF YOU OBJECT, WE WILL NO LONGER
+          PROCESS YOUR PERSONAL DATA CONCERNED UNLESS WE CAN DEMONSTRATE
+          COMPELLING LEGITIMATE GROUNDS FOR THE PROCESSING WHICH OVERRIDE YOUR
+          INTERESTS, RIGHTS AND FREEDOMS, OR THE PROCESSING IS FOR THE PURPOSE
+          OF ASSERTING, EXERCISING OR DEFENDING LEGAL CLAIMS (OBJECTION UNDER
+          ARTICLE 21(1) DSGVO).
+        </Text>
+        <Text>
+          IF YOUR PERSONAL DATA ARE PROCESSED FOR THE PURPOSE OF DIRECT
+          MARKETING, YOU HAVE THE RIGHT TO OBJECT AT ANY TIME TO THE PROCESSING
+          OF PERSONAL DATA CONCERNING YOU FOR THE PURPOSE OF SUCH MARKETING;
+          THIS ALSO APPLIES TO PROFILING INSOFAR AS IT IS RELATED TO SUCH DIRECT
+          MARKETING. IF YOU OBJECT, YOUR PERSONAL DATA WILL SUBSEQUENTLY NO
+          LONGER BE USED FOR THE PURPOSE OF DIRECT MARKETING (OBJECTION PURSUANT
+          TO ARTICLE 21 (2) DSGVO).
+        </Text>
+        <Heading size="sm" as="h3">
+          Right of appeal to the competent supervisory authority
+        </Heading>
+        <Text>
+          In the event of breaches of the GDPR, data subjects shall have a right
+          of appeal to a supervisory authority, in particular in the Member
+          State of their habitual residence, their place of work or the place of
+          the alleged breach. The right of appeal is without prejudice to other
+          administrative or judicial remedies.
+        </Text>
+        <Heading size="sm" as="h3">
+          Right to data portability
+        </Heading>
+        <Text>
+          You have the right to have data that we process automatically on the
+          basis of your consent or in fulfillment of a contract handed over to
+          you or to a third party in a common, machine-readable format. If you
+          request the direct transfer of the data to another controller, this
+          will only be done insofar as it is technically feasible.
+        </Text>
+        <Heading size="sm" as="h3">
+          Information, correction and deletion
+        </Heading>
+        <Text>
+          Within the framework of the applicable legal provisions, you have the
+          right at any time to free information about your stored personal data,
+          its origin and recipient and the purpose of data processing and, if
+          necessary, a right to correction or deletion of this data. For this
+          purpose, as well as for further questions on the subject of personal
+          data, you can contact us at any time.
+        </Text>
+        <Heading size="sm" as="h3">
+          Right to restriction of processing
+        </Heading>
+        <Text>
+          You have the right to request the restriction of the processing of
+          your personal data. For this purpose, you can contact us at any time.
+          The right to restriction of processing exists in the following cases:
+        </Text>
+        <ul>
+          <li>
+            <Text>
+              You have the right to request the restriction of the processing of
+              your personal data. For this purpose, you can contact us at any
+              time. The right to restriction of processing exists in the
+              following cases:
+            </Text>
+          </li>
+          <li>
+            <Text>
+              If the processing of your personal data happened/is happening
+              unlawfully, you may request the restriction of data processing
+              instead of erasure.
+            </Text>
+          </li>
+          <li>
+            <Text>
+              If we no longer need your personal data, but you need it to
+              exercise, defend or enforce legal claims, you have the right to
+              request restriction of the processing of your personal data
+              instead of deletion.
+            </Text>
+          </li>
+          <li>
+            <Text>
+              If you have lodged an objection pursuant to Art. 21 (1) DSGVO, a
+              balancing of your and our interests must be carried out. As long
+              as it has not yet been determined whose interests prevail, you
+              have the right to request the restriction of the processing of
+              your personal data.
+            </Text>
+          </li>
+        </ul>
+        <Text>
+          If you have restricted the processing of your personal data, this data
+          may - apart from being stored - only be processed with your consent or
+          for the assertion, exercise or defense of legal claims or for the
+          protection of the rights of another natural or legal person or for
+          reasons of an important public interest of the European Union or a
+          Member State.
+        </Text>
+        <Heading size="sm" as="h3">
+          SSL or TLS encryption
+        </Heading>
+        <Text>
+          This site uses SSL or TLS encryption for security reasons and to
+          protect the transmission of confidential content, such as orders or
+          requests that you send to us as the site operator. You can recognize
+          an encrypted connection by the fact that the address line of the
+          browser changes from `&quot;http://`&quot; to `&quot;https://`&quot;
+          and by the lock symbol in your browser line.
+        </Text>
+        <Text>
+          If SSL or TLS encryption is activated, the data you transmit to us
+          cannot be read by third parties.
+        </Text>
+        <Text>
+          Source:
+          <Text as="a" href="https://www.e-recht24.de">
+            eRecht24
+          </Text>
+        </Text>
+      </Stack>
+      <Footer css={{ marginTop: '2rem', paddingBottom: '2.5rem' }}>
         <Link as={GatsbyLink} to="/">
           CV
         </Link>


### PR DESCRIPTION
fix: fix footer position to always be at the bottom even when the text of imprint and privacy pages do not fill the whole height